### PR TITLE
Add settings page with auto-convert and shortcut options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This extension allows you to write emails in Markdown when composing a message in Gmail. Convert the Markdown to rich text via the provided context menu item or with the keyboard shortcut `Ctrl+Shift+M`.
 
+An options page allows you to configure automatic conversion on send, parser settings, and a custom keyboard shortcut.
+
 ## Installation
 1. Clone this repository.
 2. Open Chrome and navigate to `chrome://extensions`.

--- a/background.js
+++ b/background.js
@@ -26,8 +26,11 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 chrome.commands.onCommand.addListener((command) => {
   if (command === "convert_markdown") {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      injectMarkdownTools(tabs[0].id);
+    chrome.storage.sync.get({ disableDefault: false }, ({ disableDefault }) => {
+      if (disableDefault) return;
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        injectMarkdownTools(tabs[0].id);
+      });
     });
   }
 });

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,79 @@
+(function() {
+  const DEFAULTS = {
+    autoConvert: false,
+    gfm: true,
+    sanitize: false,
+    shortcut: 'Ctrl+Shift+M',
+    disableDefault: false
+  };
+
+  chrome.storage.sync.get(DEFAULTS, (opts) => {
+    const {autoConvert, shortcut} = opts;
+
+    if (autoConvert) {
+      observeSendButton(() => convertMarkdown(opts));
+    }
+
+    if (shortcut) {
+      document.addEventListener('keydown', (e) => {
+        if (matchesShortcut(e, shortcut)) {
+          e.preventDefault();
+          convertMarkdown(opts);
+        }
+      });
+    }
+  });
+
+  function matchesShortcut(e, combo) {
+    const parts = combo.toLowerCase().split('+');
+    const key = parts.pop();
+    const ctrl = parts.includes('ctrl');
+    const shift = parts.includes('shift');
+    const alt = parts.includes('alt');
+    return e.key.toLowerCase() === key &&
+           e.ctrlKey === ctrl &&
+           e.shiftKey === shift &&
+           e.altKey === alt;
+  }
+
+  function observeSendButton(callback) {
+    const observer = new MutationObserver(() => {
+      const btn = document.querySelector('div[aria-label^="Send"]');
+      if (btn) {
+        btn.addEventListener('click', () => callback(), true);
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+  }
+
+  function loadMarked(cb) {
+    if (window.marked) {
+      cb();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = chrome.runtime.getURL('marked.min.js');
+    script.onload = cb;
+    document.documentElement.appendChild(script);
+  }
+
+  function convertMarkdown(opts) {
+    loadMarked(() => {
+      const emailBody = document.querySelector('div[aria-label="Message Body"][contenteditable="true"]');
+      if (!emailBody || typeof marked?.parse !== 'function') return;
+      const selection = window.getSelection();
+      const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      const markedOpts = { gfm: opts.gfm, sanitize: opts.sanitize };
+      if (range && emailBody.contains(range.commonAncestorContainer) && selection.toString().trim()) {
+        const tempContainer = document.createElement('div');
+        tempContainer.innerHTML = marked.parse(selection.toString(), markedOpts);
+        range.deleteContents();
+        range.insertNode(tempContainer);
+      } else {
+        const html = marked.parse(emailBody.innerText, markedOpts);
+        emailBody.innerHTML = html;
+      }
+    });
+  }
+})();

--- a/injector.js
+++ b/injector.js
@@ -12,22 +12,24 @@
     if (emailBody && typeof marked?.parse === 'function') {
       clearInterval(interval);
 
-      const selection = window.getSelection();
-      const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      chrome.storage.sync.get({ gfm: true, sanitize: false }, (opts) => {
+        const selection = window.getSelection();
+        const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
 
-      if (range && emailBody.contains(range.commonAncestorContainer)) {
-        const selectedText = selection.toString();
-        if (selectedText.trim()) {
-          const tempContainer = document.createElement('div');
-          tempContainer.innerHTML = marked.parse(selectedText);
-          range.deleteContents();
-          range.insertNode(tempContainer);
+        if (range && emailBody.contains(range.commonAncestorContainer)) {
+          const selectedText = selection.toString();
+          if (selectedText.trim()) {
+            const tempContainer = document.createElement('div');
+            tempContainer.innerHTML = marked.parse(selectedText, { gfm: opts.gfm, sanitize: opts.sanitize });
+            range.deleteContents();
+            range.insertNode(tempContainer);
+          }
+        } else {
+          const markdown = emailBody.innerText;
+          const html = marked.parse(markdown, { gfm: opts.gfm, sanitize: opts.sanitize });
+          emailBody.innerHTML = html;
         }
-      } else {
-        const markdown = emailBody.innerText;
-        const html = marked.parse(markdown);
-        emailBody.innerHTML = html;
-      }
+      });
     } else {
       attempts++;
       if (attempts > MAX_ATTEMPTS) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,19 @@
   "name": "Markdown for Gmail",
   "version": "1.0",
   "description": "Write emails in Markdown and convert them to rich text via right-click or shortcut.",
-  "permissions": ["contextMenus", "scripting", "activeTab"],
+  "permissions": ["contextMenus", "scripting", "activeTab", "storage"],
   "host_permissions": ["https://mail.google.com/*"],
   "background": {
     "service_worker": "background.js"
   },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "js": ["contentScript.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "action": {
     "default_icon": "icons/icon.png",
     "default_title": "Markdown for Gmail"

--- a/options.html
+++ b/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Markdown for Gmail Options</title>
+</head>
+<body>
+  <h1>Markdown for Gmail Options</h1>
+  <label><input type="checkbox" id="autoConvert"> Convert on Send</label><br>
+  <label><input type="checkbox" id="gfm"> GitHub flavored Markdown</label><br>
+  <label><input type="checkbox" id="sanitize"> Sanitize HTML</label><br>
+  <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M"></label><br>
+  <label><input type="checkbox" id="disableDefault"> Disable default shortcut</label><br>
+  <button id="save">Save</button>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,29 @@
+function saveOptions() {
+  const opts = {
+    autoConvert: document.getElementById('autoConvert').checked,
+    gfm: document.getElementById('gfm').checked,
+    sanitize: document.getElementById('sanitize').checked,
+    shortcut: document.getElementById('shortcut').value.trim(),
+    disableDefault: document.getElementById('disableDefault').checked
+  };
+  chrome.storage.sync.set(opts);
+}
+
+function restoreOptions() {
+  chrome.storage.sync.get({
+    autoConvert: false,
+    gfm: true,
+    sanitize: false,
+    shortcut: 'Ctrl+Shift+M',
+    disableDefault: false
+  }, (items) => {
+    document.getElementById('autoConvert').checked = items.autoConvert;
+    document.getElementById('gfm').checked = items.gfm;
+    document.getElementById('sanitize').checked = items.sanitize;
+    document.getElementById('shortcut').value = items.shortcut;
+    document.getElementById('disableDefault').checked = items.disableDefault;
+  });
+}
+
+document.getElementById('save').addEventListener('click', saveOptions);
+document.addEventListener('DOMContentLoaded', restoreOptions);


### PR DESCRIPTION
## Summary
- implement options page for configuring extension features
- allow disabling default shortcut and add custom hotkey support
- inject user markdown parser preferences into conversion logic
- add content script to handle auto-convert on Send and hotkey
- document the new configuration page

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6853e7ef15e0832397350c9382a573bd