### PR TITLE
Add options save message

### DIFF
--- a/options.html
+++ b/options.html
@@ -13,6 +13,7 @@
   <label>Custom Shortcut: <input type="text" id="shortcut" placeholder="Ctrl+Shift+M"></label><br>
   <label><input type="checkbox" id="disableDefault"> Disable default shortcut</label><br>
   <button id="save">Save</button>
+  <div id="status"></div>
   <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -7,7 +7,15 @@ function saveOptions() {
     shortcut: document.getElementById('shortcut').value.trim(),
     disableDefault: document.getElementById('disableDefault').checked
   };
-  chrome.storage.sync.set(opts);
+  chrome.storage.sync.set(opts, () => {
+    const status = document.getElementById('status');
+    if (status) {
+      status.textContent = 'Options saved';
+      setTimeout(() => {
+        status.textContent = '';
+      }, 1500);
+    }
+  });
 }
 
 function restoreOptions() {


### PR DESCRIPTION
## Summary
- show a brief confirmation after saving options
- provide a status div in the options UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff80eb0c83239b3f960cb352d7b6